### PR TITLE
Rewrite repair.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,92 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 `cassandra-repair` will iterate through all keyspaces and repair each column_family individually on each cassandra node.
 
-REQUIRED: This requires that this process reach each cassandra node to execute `nodetool` and `cqlsh` commands.
+### Requirements
+This requires that this process reach each cassandra node to execute `nodetool` and `cqlsh` commands. You must include **ALL** Cassandra nodes. Failure to do so will result in a portion of the ring not being repaired and data inconsistencies.
 
 Fill in config.yaml with your cassandra nodes.
 ```
-ip: <any cassandra node>
+# Default values included. The only required setting is "hosts"
+nodetool_path: /usr/bin/nodetool
+connect: <First host in hosts>
+timeout: 3600
+retries: 3
+redis: 'localhost:6379'
 hosts:
     - list
     - all
@@ -27,3 +33,21 @@ optional arguments:
   -h, --help            show this help message and exit
   --config CONFIG_FILE
 ```
+
+* `hosts` - yaml list of cassandra nodes. You must include all nodes. This is a required configuration setting.
+* `nodetool_path` - path to nodetool
+* `connect` - The cassandra node that will be queried for keyspace/columnfamily information. Default is the first host from the hosts list.
+* `timeout` - Repairs are notorious for hanging. This will kill the repair job if it extents past this value in seconds. Currently, timed out jobs are not retried. Default: 3600 sec
+* `retries` - The number of times the job will retry a failure.
+* `redis` - The redis server to connect too.
+* `blacklist` - List of keyspaces not to repair. They will be skipped.
+
+### Redis
+Redis support has been added to maintain state between runs. This state can then be used externally to monitor your Repair.
+Currently supported values:
+* `REPAIR_STATUS` - Current status of the repair job. `completed`, `running`, `error: some error`
+* `REPAIR_START_TIME` - The time the repair started in epoch.
+* `REPAIR_CURRENT_JOB` - The current `host/keyspace.columnfamily` that is being repaired.
+* `REPAIR_FAILED_JOBS` - Json encoded list of failed jobs. `["host/keyspace.columnfamily"]`
+* `REPAIR_TOTAL_TIME` - The total time of the repair in epoch.
+* `REPAIR_LAST_SUCCESSFUL_RUN` - The epoch timestamp of the last successful repair.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# Add support for the following
+
+- [x] Add timeout support for stuck repairs - 2/1/2017
+- [x] default timeout value - 2/1/2017
+- [ ] Store averaged timeout per repair in redis
+- [x] Store repair statuses in redis - 2/2/2017
+- [ ] Retry all failures again
+- [ ] Order repairs by oldest successful repair time (Ensure failures are done first)
+- [ ] Seed timeout values in config file for new redis

--- a/cassandra-repair.py
+++ b/cassandra-repair.py
@@ -1,82 +1,227 @@
-#!/opt/cassandra-repair/.venv/bin/python
+#!/usr/bin/env python3
 
 import argparse
+import json
+import logging
 import os
+import redis
 import subprocess
 import time
 import yaml
 
 from datetime import timedelta
-from socket import gethostname
+from enum import Enum
 from sys import argv, exit
 
-failures = []
-total_time = 0.0
 
-FNULL = open(os.devnull, 'w')
+class RepairManager():
+    def __init__(self, config_file):
+        self._logger = logging.getLogger(__name__)
+        self._read_config(config_file)
 
-def read_config(config_file):
-    ''' Load the configuration file. '''
-    with open(config_file, 'r') as f:
         try:
-           config = yaml.load(f)
-        except yaml.YAMLError as exc:
-            print 'ERROR: Invalid yaml, unable to load config file.'
-            print exc
+            host, port = self._redis_host.split(':')
+            self._redis = redis.StrictRedis(host=host, port=port, db=0)
+        except:
+            self._logger.critical("Unable to connect to redis")
             exit(1)
 
-    options = {}
-    options['nodetool'] = config.get('nodetool_path', '/usr/bin/nodetool')
-    options['hostlist'] = config.get('hosts')
-    options['keyspaces'] = config.get('keyspaces')
-    options['retries'] = config.get('retries', '5')
-    options['blacklist'] = config.get('blacklist', [])
-    options['ip'] = config.get('ip', '127.0.0.1')
-    return options
+        self._prep_redis()
+        self._check_for_nodetool()
+        self._keyspace_map = self._get_keyspace_info()
+        self._failures = []
+        self._start_time = None
+        self._cluster_pause = 1
 
-def get_keyspaces(ip):
-    cmd = ['cqlsh', ip, '-e', 'DESC KEYSPACES']
-    return subprocess.check_output(cmd).strip().split()
+    def _prep_redis(self):
+        self._redis.set('REPAIR_STATUS', 'running')
+        self._redis.delete('REPAIR_START_TIME')
+        self._redis.delete('REPAIR_CURRENT_JOB')
+        self._redis.delete('REPAIR_FAILED_JOBS')
+        self._redis.delete('REPAIR_TOTAL_TIME')
 
-def get_columnfamilies(ip, keyspace):
-    cmd = ['cqlsh', ip, '-e', "select columnfamily_name from system.schema_columnfamilies WHERE keyspace_name='%s';" % keyspace]
-    output = subprocess.check_output(cmd).strip().split('\n')
-    return map(str.strip, output[2:-2])
+    def _read_config(self, config_file):
+        """
+        Load the configuration file.
+        """
+        self._logger.debug("Reading config file {}".format(config_file))
+        with open(config_file, 'r') as f:
+            try:
+               config = yaml.load(f)
+            except yaml.YAMLError as exc:
+                self._logger.critical('Invalid yaml, unable to load config file.')
+                self._logger.critical(exc)
+                exit(1)
 
-def check_for_nodetool(nodetool):
-    ''' Ensure nodetool command exists. '''
-    if not os.path.isfile(nodetool):
-        print "ERROR: Unable to find nodetool command at %s" % nodetool
-        exit(1)
+        if not config:
+            config = {}
 
-def run_repair(host, keyspace, cf, retries=3):
-    global total_time
-    attempts = 0
-    cmd = ['nodetool', '-h', host, 'repair', '-pr', keyspace, cf]
+        self._nodetool = config.get('nodetool_path', '/usr/bin/nodetool')
+        self._hostlist = config.get('hosts', ['127.0.0.1'])
+        self._retries = config.get('retries', 3)
+        self._default_timeout = config.get('timeout', 3600)
+        self._blacklist = config.get('blacklist', [])
+        self._cqlsh_ip = config.get('connect', self._hostlist[0])
+        self._redis_host = config.get('redis', 'localhost:6379')
 
-    while attempts < retries:
+    def _decode(self, value):
+        """
+        In python3, subprocess returns byte objects instead of nice strings.
+        """
+        if isinstance(value, list):
+            return [s.decode('utf-8') for s in value]
+        else:
+            return value.decode('utf-8')
+
+    def _get_keyspace_info(self):
+        self._logger.info("Gathering cassandra keyspace information.")
+        info = {}
+        keyspaces = self._get_keyspaces()
+        for k in keyspaces:
+            info[k] = self._get_columnfamilies(k)
+        return info
+
+    def _get_keyspaces(self):
         try:
-            start_time = time.time()
-            subprocess.check_call(cmd, stdout=FNULL, stderr=subprocess.STDOUT)
-            success = True
-            break
+            cmd = ['cqlsh', self._cqlsh_ip, '-e', 'DESC KEYSPACES']
+            output = subprocess.check_output(cmd).strip().split()
         except subprocess.CalledProcessError as err:
-            attempts += 1
-            success = False
-            elapsed_time = time.time() - start_time
-            total_time += elapsed_time
-            print "%s: Repair attempt %s on %s FAILED after %s sec." % (host, str(attempts), keyspace, str(elapsed_time))
-            time.sleep(5)
+            self._logger.critical("Unable to connect to cassandra at {}".format(self._cqlsh_ip))
+            self._redis.set("REPAIR_STATUS", "error: unable to connect to cassandra")
+            exit(1)
 
-    if success:
-        elapsed_time = time.time() - start_time
-        total_time += elapsed_time
-        print "%s completed in %s sec" % (host, str(elapsed_time))
-    else:
-        # TODO: Do something here eventually. Alert/notify.
-        failures.append("%s: %s.%s" % (host, keyspace, cf))
-        print "Repair attempts exhausted. Repair failed for %s.%s" % (host, keyspace)
+        formatted_output = self._decode(output)
+        formatted_output.remove('system') # Do not repair the system keyspace
+        self._logger.debug("Found {} keyspaces: {}".format(len(formatted_output), formatted_output))
 
+        if self._blacklist:
+            self._logger.warning("Blacklisting {} keyspaces, they will not be repaired.".format(self._blacklist))
+            for keyspace in self._blacklist:
+                formatted_output.remove(keyspace)
+
+        return formatted_output
+    
+    def _get_columnfamilies(self, keyspace):
+        cmd = ['cqlsh', self._cqlsh_ip, '-e', "select columnfamily_name from system.schema_columnfamilies WHERE keyspace_name='{}';".format(keyspace)]
+        output = self._decode(subprocess.check_output(cmd)).strip().split('\n')
+        formatted_output = map(str.strip, output[2:-2])
+        return formatted_output
+    
+    def _check_for_nodetool(self):
+        ''' Ensure nodetool command exists. '''
+        if not os.path.isfile(self._nodetool):
+            self._logger.critical("Unable to find nodetool command at %s" % nodetool)
+            exit(1)
+
+    def _add_failure(self, job):
+        f = "{}/{}.{}".format(job.host, job.keyspace, job.cf)
+        self._failures.append(f)
+        self._redis.set("REPAIR_FAILED_JOBS", json.dumps(self._failures))
+
+    def repair_all(self):
+        self._logger.info("Starting a full repair.")
+        self._logger.debug("Repairing {} keyspaces.".format(self._keyspace_map.keys()))
+
+        self._start_time = time.time()
+        self._redis.set('REPAIR_START_TIME', self._start_time)
+
+        for keyspace, columnfamilies in self._keyspace_map.items():
+            for cf in columnfamilies:
+                for host in self._hostlist:
+
+                    # Run the repair
+                    self._redis.set("REPAIR_CURRENT_JOB", "{}/{}.{}".format(host, keyspace, cf))
+                    job = RepairJob(host, keyspace, cf, self._default_timeout, self._retries)
+                    result = job.run()
+                    self._redis.delete("REPAIR_CURRENT_JOB")
+
+                    if result.status is RepairJobStatus.SUCCESS:
+                        self._logger.info("{} succeeded for {}.{} with {} failures".format(host, keyspace, cf, result.failures))
+                    elif result.status is RepairJobStatus.FAILED:
+                        self._add_failure(job)
+                    elif result.status is RepairJobStatus.TIMEOUT:
+                        self._add_failure(job)
+                        self._logger.debug("{} timed out for {}.{}".format(host, keyspace, cf))
+                    else:
+                        self._logger.critical("Unknown job result on {} for {}.{}: {}".format(host, keyspace, cf, result))
+
+                    time.sleep(self._cluster_pause) # Give the cluster a few seconds to settle down between repairs.
+
+        total_time = time.time() - self._start_time
+        self._redis.set("REPAIR_TOTAL_TIME", total_time)
+
+        if self._failures:
+            self._redis.set("REPAIR_STATUS", "error: there were {} failures".format(len(self._failures)))
+            self._logger.error("Repair completed with {} failures in {} seconds.".format(len(self._failures), str(timedelta(seconds=total_time))))
+            for f in self._failures:
+                self._logger.error("Failed: {}".format(f))
+        else:
+            self._redis.set("REPAIR_STATUS", "complete")
+            self._redis.set("REPAIR_LAST_SUCCESSFUL_RUN", time.time())
+            self._logger.info("Repair completed in {} seconds.".format(str(timedelta(seconds=total_time))))
+
+
+class RepairJobStatus(Enum):
+        SUCCESS = 0
+        FAILED = 1
+        TIMEOUT = 2
+
+
+class RepairJobResult():
+    def __init__(self, status, elapsed_time):
+        self.status = status
+        self.elapsed_time = elapsed_time
+        self.failures = 0
+
+    def __str__(self):
+        return "{} in {} sec with {} failures.".format(self.status, self.elapsed_time, self.failures)
+
+
+class RepairJob():
+    def __init__(self, host, keyspace, columnfamily, timeout=3600, retries=3):
+        self.host = host
+        self.keyspace = keyspace
+        self.cf = columnfamily
+        self._timeout = timeout
+        self._retries = retries
+        self._FNULL = open(os.devnull, 'w')
+        self._attempts = 0
+        self._start_time = None
+        self._failure_pause = 1
+        self.status = None
+        self.total_time = 0
+
+    def _elapsed_time(self):
+        return time.time() - self._start_time
+
+    def _update_time(self):
+        self.total_time += self._elapsed_time()
+
+    def run(self):
+        cmd = ['nodetool', '-h', self.host, 'repair', '-pr', self.keyspace, self.cf]
+        while self._attempts <= self._retries:
+            logging.debug("{}/{}.{} starting attempt {} with {} sec timeout".format(self.host, self.keyspace, self.cf, self._attempts + 1, self._timeout))
+            try:
+                self._start_time = time.time()
+                subprocess.check_call(cmd, stdout=self._FNULL, stderr=subprocess.STDOUT, timeout=self._timeout)
+                self._update_time()
+                logging.debug("{}/{}.{} completed in {} sec attempt {}".format(self.host, self.keyspace, self.cf, self._elapsed_time(), self._attempts + 1))
+                return RepairJobResult(RepairJobStatus.SUCCESS, self.total_time)
+
+            except subprocess.TimeoutExpired as err:
+                # NOTE: Timeout exceptions are not retried. This might change in the future.
+                self._update_time()
+                logging.error("{}/{}.{} timeout in {} sec attempt {}".format(self.host, self.keyspace, self.cf, self._elapsed_time(), self._attempts + 1))
+                return RepairJobResult(RepairJobStatus.TIMEOUT, self.total_time)
+
+            except subprocess.CalledProcessError as err:
+                logging.warning("{}/{}.{} failed in {} sec attempt {}".format(self.host, self.keyspace, self.cf, self._elapsed_time(), self._attempts + 1))
+                self._attempts += 1
+                self._update_time()
+                time.sleep(self._failure_pause)
+
+        logging.error("{}/{}.{} failed in {} sec, retries exhausted.".format(self.host, self.keyspace, self.cf, self.total_time))
+        return RepairJobResult(RepairJobStatus.FAILED, self.total_time)
 
 
 if __name__ == '__main__':
@@ -85,29 +230,7 @@ if __name__ == '__main__':
     parser.add_argument('--config', dest='config_file', default='config.yaml')
     args = parser.parse_args()
 
-    options = read_config(args.config_file)
+    logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=logging.DEBUG)
 
-    check_for_nodetool(options['nodetool'])
-
-    keyspaces = sorted(get_keyspaces(options['ip']))
-
-    print "#### Starting repair ####"
-
-    for keyspace in keyspaces:
-        columnfamilies = get_columnfamilies(options['ip'], keyspace)
-        if keyspace == 'system':
-            # Do not repair system
-            continue
-        elif keyspace in options['blacklist']:
-            print "%s blacklisted, skipping..." % keyspace
-            continue
-        else:
-            for cf in columnfamilies:
-                print "\nRepairing %s.%s..." % (keyspace, cf)
-                for host in options['hostlist']:
-                    run_repair(host, keyspace, cf, options['retries'])
-
-    print "\n\n###############################"
-    print "Repair total time: %s" % str(timedelta(seconds=total_time))
-    print "There were {} failures".format(len(failures))
-    print "\n".join(failures)
+    repair_manager = RepairManager(args.config_file)
+    repair_manager.repair_all()

--- a/config.yaml
+++ b/config.yaml
@@ -1,15 +1,8 @@
-ip: cassandra-node-01
-retries: 5
+connect: 10.1.36.199
+timeout: 300
+retries: 3
 hosts:
-  - 10.0.1.1
-  - 10.0.1.1
-  - 10.0.1.1
-  - 10.0.2.1
-  - 10.0.2.1
-  - 10.0.2.1
-  - 10.0.3.1
-  - 10.0.3.1
-  - 10.0.3.1
-
-blacklist:
-  - example_keyspace
+  - 10.1.36.199
+  - 10.1.36.4
+  - 10.1.36.222
+redis: 'localhost:6379'


### PR DESCRIPTION
- Re-write the script to be an importable module. This will allow failures to be more easily fixed.
- Added support for timeouts. Occasionally, repairs can get hung. This will kill the repair job if it takes too long.
- Added redis support to maintain state for external monitoring.
- Upgraded to python3
- Added more robust logging.